### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,17 @@
 ```
 ; enable the gRPC extension
 extension=grpc.so
-
-; Ref.: https://github.com/colopl/laravel-spanner/issues/12
-grpc.enable_fork_support = 1
 ```
 If you use library outside Google App Engine please check [gRPC installation guide](https://cloud.google.com/php/grpc).
+
+If the `pcntl` extension is enabled, you must set `usePcntl` to `true` in your `.psysh.php` file to avoid gRPC interactions hanging in Tinker:
+```php
+<?php
+
+return [
+    'usePcntl' => false,
+];
+```
 
 ### Usage
 To access FirestoreClient simply use `Firestore` facade for example:


### PR DESCRIPTION
This PR updates `README.md` and adds a workaround to avoid gRPC interactions hanging in Tinker.

The workaround is based on the following:
https://github.com/grpc/grpc/issues/31772#issuecomment-1901093644

With PHP 8.3.12, Laravel 11.29.0, gRPC 1.67.0, and `grpc.enable_fork_support = 1`, Tinker never reaches the prompt, it keeps hanging after `Psy Shell v0.12.4 (PHP 8.3.12 — cli) by Justin Hileman`.
Therefore, `grpc.enable_fork_support = 1` seems to be counterproductive now.

Please consider merging.
Thank you!



